### PR TITLE
fixes for ida 7 compatability

### DIFF
--- a/idaref.py
+++ b/idaref.py
@@ -4,8 +4,46 @@ import os
 import inspect
 import glob
 
+
+initialized = False
+insref_g = None
+#we try because of ida versions below 6.8, and write action handlers below
+try:
+    class StopHandler(idaapi.action_handler_t):
+        def __init__(self):
+            idaapi.action_handler_t.__init__(self)
+            
+        def activate(self, ctx):
+            b = idaref_plugin_t()
+            b.stop()
+            return 1
+        # This action is always available.
+        def update(self, ctx):
+            return idaapi.AST_ENABLE_ALWAYS
+
+except AttributeError:
+    pass
+
+try:
+    class StartHandler(idaapi.action_handler_t):
+        def __init__(self):
+            idaapi.action_handler_t.__init__(self)
+            
+        def activate(self, ctx):
+            b = idaref_plugin_t()
+            b.start()
+            return 1
+        # This action is always available.
+        def update(self, ctx):
+            return idaapi.AST_ENABLE_ALWAYS
+
+except AttributeError:
+    pass
+
 class InstructionReference(idaapi.simplecustviewer_t):
-    def __init__(self):
+    def __init__(self, owner):
+        super(InstructionReference, self).__init__()
+        self.owner = owner
         self.ref_term = False
         self.inst_map = {}
         self.last_inst = None
@@ -34,11 +72,43 @@ class InstructionReference(idaapi.simplecustviewer_t):
             if(not idaapi.simplecustviewer_t.Create(self, self.title)):
                 print "Unable to open"
                 return False
-
-            self.menu_update = self.AddPopupMenu("Update View")
-            self.menu_lookup = self.AddPopupMenu("Lookup Instruction")
-            self.menu_autorefresh = self.AddPopupMenu("Toggle Auto-refresh")
-            self.change_arch = self.AddPopupMenu("Change Architecture")
+            
+            if IDA_SDK_VERSION >= 700:
+                self.menu_update = 1
+                self.menu_lookup = 2
+                self.menu_autorefresh = 3
+                self.change_arch = 4
+                
+                class Hooks(idaapi.UI_Hooks):
+                    class PopupActionHandler(action_handler_t):
+                        def __init__(self, owner, menu_id):
+                            self.owner = owner
+                            self.menu_id = menu_id
+                        
+                        def activate(self, ctx):
+                            self.owner.OnPopupMenu(self.menu_id)
+                            
+                        def update(self, ctx):
+                            return idaapi.AST_ENABLE_ALWAYS
+                            
+                    def __init__(self, form):
+                        idaapi.UI_Hooks.__init__(self)
+                        self.form = form
+                    def finish_populating_widget_popup(self, widget, popup):
+                        if self.form.title == get_widget_title(widget):
+                            attach_dynamic_action_to_popup(widget, popup, action_desc_t(None, "Update View", self.PopupActionHandler(self.form, self.form.menu_update),   None, None, -1))
+                            attach_dynamic_action_to_popup(widget, popup, action_desc_t(None, "Lookup Instruction", self.PopupActionHandler(self.form, self.form.menu_lookup),   None, None, -1))
+                            attach_dynamic_action_to_popup(widget, popup, action_desc_t(None, "Toggle Auto-refresh",      self.PopupActionHandler(self.form, self.form.menu_autorefresh),   None, None, -1))
+                            attach_action_to_popup(widget, popup, "-", None)
+                            attach_dynamic_action_to_popup(widget, popup, action_desc_t(None, "Change Architecture", self.PopupActionHandler(self.form, self.form.change_arch),  None, None, -1))
+                            attach_action_to_popup(widget, popup, "-", None)        
+                self.hooks = Hooks(self)
+                self.hooks.hook()
+            else:
+                self.menu_update = self.AddPopupMenu("Update View")
+                self.menu_lookup = self.AddPopupMenu("Lookup Instruction")
+                self.menu_autorefresh = self.AddPopupMenu("Toggle Auto-refresh")
+                self.change_arch = self.AddPopupMenu("Change Architecture")
 
             self.Show()
 
@@ -240,7 +310,7 @@ Define an IDA Python plugin required class and function.
 Inpired by idarest plugin.
 """
 
-MENU_PATH = 'Edit/Other'
+MENU_PATH = 'Edit/idaref/'
 class idaref_plugin_t(idaapi.plugin_t):
     flags = idaapi.PLUGIN_KEEP
     comment = ""
@@ -248,9 +318,11 @@ class idaref_plugin_t(idaapi.plugin_t):
     help = "IdaRef: Presents complete instruction reference for an instruction under cursor"
     wanted_name = "IDA Instruction Reference"
     wanted_hotkey = "Alt-8"
+    website = "https://github.com/nologic/idaref"
 
     def _add_menu(self, *args):
         ctx = idaapi.add_menu_item(*args)
+            
         if ctx is None:
             idaapi.msg("Add failed!\n")
             return False
@@ -260,8 +332,39 @@ class idaref_plugin_t(idaapi.plugin_t):
 
     def _add_menus(self):
         ret = []
-        ret.append(self._add_menu(MENU_PATH, 'Stop IdaRef', '', 1, self.stop, tuple()))
-        ret.append(self._add_menu(MENU_PATH, 'Start IdaRef', '', 1, self.start, tuple()))
+        if idaapi.IDA_SDK_VERSION <= 695:
+            ret.append(self._add_menu(MENU_PATH, 'Stop IdaRef', '', 1, self.stop, tuple()))
+            ret.append(self._add_menu(MENU_PATH, 'Start IdaRef', '', 1, self.start, tuple()))
+        
+        if idaapi.IDA_SDK_VERSION >= 700:
+            action_desc = idaapi.action_desc_t(
+                'idaref:stop', # The action name. Must be unique
+                'Stop Idaref', # Action Text
+                StopHandler(), # Action handler
+                '', # Optional shortcut
+                'Stop Idaref' # Action tooltip
+            )
+            idaapi.register_action(action_desc)
+            idaapi.attach_action_to_menu(
+                MENU_PATH,
+                'idaref:stop',
+                idaapi.SETMENU_APP
+            )
+            
+            action_desc = idaapi.action_desc_t(
+                'idaref:start', # The action name. Must be unique
+                'Start Idaref', # Action Text
+                StartHandler(), # Action handler
+                '', # Optional shortcut
+                'Start Idaref' # Action tooltip
+            )
+            idaapi.register_action(action_desc)
+            idaapi.attach_action_to_menu(
+                MENU_PATH,
+                'idaref:start',
+                idaapi.SETMENU_APP
+            )
+           
         
         if False in ret:
             return idaapi.PLUGIN_SKIP
@@ -270,31 +373,36 @@ class idaref_plugin_t(idaapi.plugin_t):
 
 
     def init(self):
-        self.ctxs = []
-        self.ref = None
-
-        ret = self._add_menus()
+        global initialized
+        ret = idaapi.PLUGIN_SKIP
+        if initialized == False:
+            initialized = True
+            self.ctxs = []
+            insref_g = None
+            ret = self._add_menus()
         idaapi.msg("IdaRef initialized\n")
 
         return ret
 
     def start(self, *args):
+        global insref_g
         idaapi.msg("Starting IdaRef\n")
         
-        if(self.ref != None and idaapi.find_tform(ref.title) == None):
+        if(insref_g != None and idaapi.find_tform(insref_g.title) == None):
             self.stop()
 
-        if(self.ref == None):
-            self.ref = InstructionReference()
+        if(insref_g == None):
+            insref_g = InstructionReference(self)
         else:
             print "IdaRef Already started"
 
     def stop(self, *args):
+        global insref_g
         idaapi.msg("Stopping IdaRef\n")
 
-        if(self.ref != None):
-            self.ref.destroy()
-            self.ref = None
+        if(insref_g != None):
+            insref_g.destroy()
+            insref_g = None
         else:
             print "IdaRef is not running"
 


### PR DESCRIPTION
Problems still exist with "Update View" action item.  as well as when clicking on an instruction for the second, third, etc times will look like 
"MOV: MOV: MOV: MOV: MOV: MOV: MOV: MOV-Move to/from Debug Register"
Hope to fix this issue at some point.  Other than that works alright

Have not tested with ida < 7 yet
  