### PR TITLE
Explicitly import IDA packages and functions

### DIFF
--- a/idaref.py
+++ b/idaref.py
@@ -3,6 +3,8 @@ import sqlite3 as sq
 import os
 import inspect
 import glob
+import idaapi
+from idc import GetMnem, ScreenEA
 
 
 initialized = False


### PR DESCRIPTION
This fixes an error on IDA 7.1 where the python interpreter cannot find
the `idaapi` package, or the `GetMnem` and `ScreenEA` functions.

Closes #18.